### PR TITLE
Correct dependency labels

### DIFF
--- a/.github/area-labeler.yml
+++ b/.github/area-labeler.yml
@@ -2,6 +2,8 @@ workflows:
   - .github/**
 documentation:
   - '**/*.md'
+dependencies:
+  - gradle/libs.versions.toml
 
 logic:
   - features/*/logic/**

--- a/.github/area-labeler.yml
+++ b/.github/area-labeler.yml
@@ -1,5 +1,5 @@
 workflows:
-  - .github/**
+  - .github/**/*.yml
 documentation:
   - '**/*.md'
 dependencies:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,5 +7,6 @@ version: 2
 updates:
   - package-ecosystem: "gradle" # See documentation for possible values
     directory: "/" # Location of package manifests
+    labels: []
     schedule:
       interval: "weekly"

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -18,12 +18,3 @@ jobs:
           configuration-path: .github/area-labeler.yml
           sync-labels: true
           dot: true
-
-      - uses: codelytv/pr-size-labeler@v1
-        with:
-          GITHUB_TOKEN: ${{ github.token }}
-          xs_label: 'size:xs'
-          s_label: 'size:s'
-          m_label: 'size:m'
-          l_label: 'size:l'
-          xl_label: 'size:xl'

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: codelytv/pr-size-labeler@v1
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
           xs_label: 'size:xs'
           s_label: 'size:s'
           m_label: 'size:m'

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -21,6 +21,7 @@ jobs:
 
       - uses: codelytv/pr-size-labeler@v1
         with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           xs_label: 'size:xs'
           s_label: 'size:s'
           m_label: 'size:m'


### PR DESCRIPTION
We don't want dependabot adding `java` everywhere, and we do want user-submitted PRs to have `dependencies`.

Also removed the size labeler, since it appears broken.