### PR TITLE
Upload nightly builds to Actions artifacts

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -1,0 +1,33 @@
+name: Build nightly
+
+on:
+  schedule:
+    - cron: '35 14 * * *'
+  workflow_dispatch:
+
+jobs:
+  build_nightly:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3.9.0
+        with:
+          java-version: 17
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2.7.0
+
+      - name: Build
+        run: ./gradlew assembleRelease
+
+      # TODO Sign release for signature stability
+
+      - name: Upload nightly
+        uses: actions/upload-artifact@v3
+        with:
+          name: nasdroid-nightly.apk
+          path: app/build/outputs/apk/release/app-release-unsigned.apk

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     strategy:
       matrix:
-        variant: [Debug, Release]
+        variant: [Debug]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Also disabled running realease build against PRs. Debug should be enough.