### PR TITLE
Revert "Try to run workflows on macos runners (#244)"

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_nightly:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     environment: nightly
     steps:
       - name: Checkout

--- a/.github/workflows/code-scanning.yml
+++ b/.github/workflows/code-scanning.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   static-analysis:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         variant: [Debug]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -8,7 +8,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This reverts commit 1a108c56a0ee855cb25180de39e64ab8432fa6cf.

Based on my highly scientific test of letting one build run with caches, macos runners are significantly slower (4m56s vs 3m32s)