### PR TITLE
Enable the use of local caching in apps feature

### DIFF
--- a/features/apps/logic/build.gradle.kts
+++ b/features/apps/logic/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     api(libs.kotlinx.datetime)
 
     implementation(projects.core.api)
+    implementation(projects.features.apps.data)
 
     implementation(libs.koin.core)
 

--- a/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/DI.kt
+++ b/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/DI.kt
@@ -1,5 +1,6 @@
 package com.nasdroid.apps.logic
 
+import com.nasdroid.apps.data.AppsDataModule
 import com.nasdroid.apps.logic.available.GetAllAvailableApps
 import com.nasdroid.apps.logic.available.GetAvailableApps as GetAvailableAppsLegacy
 import com.nasdroid.apps.logic.available.InstallApplication
@@ -22,6 +23,8 @@ import org.koin.dsl.module
  * A Koin module to inject the apps logic dependency graph.
  */
 val AppsLogicModule = module {
+    includes(AppsDataModule)
+
     factoryOf(::GetAllAvailableApps)
     factoryOf(::GetAvailableAppsLegacy)
     factoryOf(::InstallApplication)

--- a/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/DeleteApp.kt
+++ b/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/DeleteApp.kt
@@ -1,18 +1,21 @@
 package com.nasdroid.apps.logic.installed
 
 import com.nasdroid.api.v2.chart.release.ChartReleaseV2Api
+import com.nasdroid.apps.data.installed.InstalledAppCache
 
 /**
  * Deletes an application and all its data (where possible). See [invoke] for details.
  */
 class DeleteApp(
-    private val chartReleaseV2Api: ChartReleaseV2Api
+    private val chartReleaseV2Api: ChartReleaseV2Api,
+    private val installedAppCache: InstalledAppCache,
 ) {
 
     /**
      * Deletes the specified application, and all its volumes.
      */
-    suspend operator fun invoke(releaseName: String, deleteUnusedImages: Boolean) {
-        chartReleaseV2Api.deleteRelease(releaseName, deleteUnusedImages)
+    suspend operator fun invoke(appName: String, deleteUnusedImages: Boolean) {
+        installedAppCache.deleteInstalledApp(appName)
+        chartReleaseV2Api.deleteRelease(appName, deleteUnusedImages)
     }
 }

--- a/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/GetInstalledApps.kt
+++ b/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/GetInstalledApps.kt
@@ -2,39 +2,68 @@ package com.nasdroid.apps.logic.installed
 
 import com.nasdroid.api.v2.chart.release.ChartRelease
 import com.nasdroid.api.v2.chart.release.ChartReleaseV2Api
+import com.nasdroid.apps.data.installed.CachedInstalledApp
+import com.nasdroid.apps.data.installed.InstalledAppCache
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onStart
 
 /**
  * Gets a list of applications installed on the system. See [invoke] for details.
  */
 class GetInstalledApps(
-    private val chartReleaseV2Api: ChartReleaseV2Api
+    private val chartReleaseV2Api: ChartReleaseV2Api,
+    private val installedAppCache: InstalledAppCache
 ) {
 
     /**
      * Gets a list of all applications installed on the system.
      */
-    suspend operator fun invoke(): List<InstalledAppOverview> {
-        val releaseDtos = chartReleaseV2Api.getChartReleases()
-        return releaseDtos
-            .map { chartRelease ->
-                InstalledAppOverview(
-                    name = chartRelease.id,
-                    version = chartRelease.humanVersion,
-                    iconUrl = chartRelease.chartMetadata.icon,
-                    catalog = chartRelease.catalog,
-                    train = chartRelease.catalogTrain,
-                    state = when (chartRelease.status) {
-                        ChartRelease.Status.ACTIVE -> InstalledAppOverview.State.ACTIVE
-                        ChartRelease.Status.STOPPED -> InstalledAppOverview.State.STOPPED
-                        ChartRelease.Status.DEPLOYING -> InstalledAppOverview.State.DEPLOYING
-                    },
-                    updateAvailable = chartRelease.updateAvailable,
-                    webPortalUrl = chartRelease.portals?.let { portals ->
-                        portals.open?.firstOrNull() ?: portals.webPortal?.firstOrNull()
+    @OptIn(ExperimentalCoroutinesApi::class)
+    operator fun invoke(): Flow<List<InstalledAppOverview>> {
+        return installedAppCache.getInstalledApps("")
+            .onStart {
+                val releaseDtos = chartReleaseV2Api.getChartReleases()
+                installedAppCache.submitInstalledApps(
+                    releaseDtos.map {
+                        CachedInstalledApp(
+                            name = it.id,
+                            version = it.humanVersion,
+                            iconUrl = it.chartMetadata.icon,
+                            catalog = it.catalog,
+                            train = it.catalogTrain,
+                            state = when (it.status) {
+                                ChartRelease.Status.DEPLOYING -> CachedInstalledApp.State.DEPLOYING
+                                ChartRelease.Status.ACTIVE -> CachedInstalledApp.State.ACTIVE
+                                ChartRelease.Status.STOPPED -> CachedInstalledApp.State.STOPPED
+                            },
+                            updateAvailable = it.updateAvailable,
+                            webPortalUrl = it.portals?.let { portals ->
+                                portals.open?.firstOrNull() ?: portals.webPortal?.firstOrNull()
+                            }
+                        )
                     }
                 )
             }
-            .sortedBy { it.name }
+            .mapLatest {
+                it.map { cachedApp ->
+                    InstalledAppOverview(
+                        name = cachedApp.name,
+                        version = cachedApp.version,
+                        iconUrl = cachedApp.iconUrl,
+                        catalog = cachedApp.catalog,
+                        train = cachedApp.train,
+                        state = when (cachedApp.state) {
+                            CachedInstalledApp.State.ACTIVE -> InstalledAppOverview.State.ACTIVE
+                            CachedInstalledApp.State.STOPPED -> InstalledAppOverview.State.STOPPED
+                            CachedInstalledApp.State.DEPLOYING -> InstalledAppOverview.State.DEPLOYING
+                        },
+                        updateAvailable = cachedApp.updateAvailable,
+                        webPortalUrl = cachedApp.webPortalUrl
+                    )
+                }.sortedBy { app -> app.name }
+            }
     }
 }
 

--- a/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/GetInstalledApps.kt
+++ b/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/GetInstalledApps.kt
@@ -21,8 +21,8 @@ class GetInstalledApps(
      * Gets a list of all applications installed on the system.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    operator fun invoke(): Flow<List<InstalledAppOverview>> {
-        return installedAppCache.getInstalledApps("")
+    operator fun invoke(searchTerm: String): Flow<List<InstalledAppOverview>> {
+        return installedAppCache.getInstalledApps(searchTerm)
             .onStart {
                 val releaseDtos = chartReleaseV2Api.getChartReleases()
                 installedAppCache.submitInstalledApps(

--- a/features/apps/ui/src/main/kotlin/com/nasdroid/apps/ui/installed/overview/InstalledAppsOverviewViewModel.kt
+++ b/features/apps/ui/src/main/kotlin/com/nasdroid/apps/ui/installed/overview/InstalledAppsOverviewViewModel.kt
@@ -2,13 +2,18 @@ package com.nasdroid.apps.ui.installed.overview
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nasdroid.apps.logic.installed.InstalledAppOverview
 import com.nasdroid.apps.logic.installed.DeleteApp
 import com.nasdroid.apps.logic.installed.GetInstalledApps
+import com.nasdroid.apps.logic.installed.InstalledAppOverview
 import com.nasdroid.apps.logic.installed.StartApp
 import com.nasdroid.apps.logic.installed.StopApp
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
 /**
@@ -21,12 +26,24 @@ class InstalledAppsOverviewViewModel(
     private val deleteApp: DeleteApp,
 ) : ViewModel() {
 
-    private val _installedApps = MutableStateFlow<List<InstalledAppOverview>?>(null)
+    private val _searchTerm = MutableStateFlow("")
+
+    private val _refreshTrigger = MutableSharedFlow<Unit>()
 
     /**
      * A list of [InstalledAppOverview]s representing all installed apps.
      */
-    val installedApps: StateFlow<List<InstalledAppOverview>?> = _installedApps
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val installedApps: StateFlow<List<InstalledAppOverview>?> = _refreshTrigger
+        .flatMapLatest { _searchTerm }
+        .flatMapLatest {
+            getInstalledApps()
+        }
+        .stateIn(
+            viewModelScope,
+            SharingStarted.Eagerly,
+            null
+        )
 
     init {
         refresh()
@@ -72,7 +89,6 @@ class InstalledAppsOverviewViewModel(
     }
 
     private suspend fun refreshSuspending() {
-        val installedApps = getInstalledApps()
-        _installedApps.emit(installedApps)
+        _refreshTrigger.emit(Unit)
     }
 }

--- a/features/apps/ui/src/main/kotlin/com/nasdroid/apps/ui/installed/overview/InstalledAppsOverviewViewModel.kt
+++ b/features/apps/ui/src/main/kotlin/com/nasdroid/apps/ui/installed/overview/InstalledAppsOverviewViewModel.kt
@@ -37,7 +37,7 @@ class InstalledAppsOverviewViewModel(
     val installedApps: StateFlow<List<InstalledAppOverview>?> = _refreshTrigger
         .flatMapLatest { _searchTerm }
         .flatMapLatest {
-            getInstalledApps()
+            getInstalledApps(it)
         }
         .stateIn(
             viewModelScope,


### PR DESCRIPTION
Installed apps overview page is now backed by a local cache, enabling improvements like instant reflection of:
- App installs (coming soon)
- App deletion
- App starts and stops
- App updating (coming soon)
- Searching installed apps (coming soon)