### PR TITLE
Enable edge-to-edge drawing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
         tools:targetApi="33">
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:windowSoftInputMode="adjustResize">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/nasdroid/MainActivity.kt
+++ b/app/src/main/java/com/nasdroid/MainActivity.kt
@@ -3,9 +3,11 @@ package com.nasdroid
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
@@ -34,7 +36,9 @@ import com.nasdroid.ui.navigation.TopLevelNavigation
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3WindowSizeClassApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+
         setContent {
             val windowSizeClass = calculateWindowSizeClass(activity = this)
             NasDroidTheme {
@@ -86,7 +90,8 @@ fun MainScreen(
         },
         navigationVisible = isNavigationVisible,
         canNavigateBack = canNavigateBack,
-        navigateBack = navController::popBackStack
+        navigateBack = navController::popBackStack,
+        modifier = Modifier.safeDrawingPadding()
     ) {
         MainNavHost(
             navController = navController,


### PR DESCRIPTION
Currently we skip actually drawing behind system bars, for the sake of smaller PRs