### PR TITLE
Enable true edge-to-edge drawing

### DIFF
--- a/app/src/main/java/com/nasdroid/MainActivity.kt
+++ b/app/src/main/java/com/nasdroid/MainActivity.kt
@@ -7,7 +7,6 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material3.windowsizeclass.ExperimentalMaterial3WindowSizeClassApi
 import androidx.compose.material3.windowsizeclass.WindowSizeClass
 import androidx.compose.material3.windowsizeclass.calculateWindowSizeClass
@@ -90,8 +89,7 @@ fun MainScreen(
         },
         navigationVisible = isNavigationVisible,
         canNavigateBack = canNavigateBack,
-        navigateBack = navController::popBackStack,
-        modifier = Modifier.safeDrawingPadding()
+        navigateBack = navController::popBackStack
     ) {
         MainNavHost(
             navController = navController,

--- a/core/design/src/main/kotlin/com/nasdroid/design/Theme.kt
+++ b/core/design/src/main/kotlin/com/nasdroid/design/Theme.kt
@@ -1,16 +1,11 @@
 package com.nasdroid.design
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
-import androidx.core.view.WindowCompat
 
 /**
  * The base NASdroid theme.
@@ -33,16 +28,6 @@ fun NasDroidTheme(
             LightColors
         }
     }
-    // If we're running on a device, we want to set the status bar color appropriately
-    val view = LocalView.current
-    if (!view.isInEditMode) {
-        SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
-        }
-    }
-
     MaterialThemeExt(
         colorScheme = colorScheme,
         content = content


### PR DESCRIPTION
This is a follow-up to the last PR, where we opted in to edge-to-edge, but didn't actually draw behind system bars