### PR TITLE
Optimistically avoid refreshing installed apps cache

### DIFF
--- a/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/DI.kt
+++ b/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/DI.kt
@@ -16,7 +16,9 @@ import com.nasdroid.apps.logic.installed.GetLogOptions
 import com.nasdroid.apps.logic.installed.RollbackApp
 import com.nasdroid.apps.logic.installed.StartApp
 import com.nasdroid.apps.logic.installed.StopApp
+import kotlinx.datetime.Clock
 import org.koin.core.module.dsl.factoryOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 /**
@@ -24,6 +26,8 @@ import org.koin.dsl.module
  */
 val AppsLogicModule = module {
     includes(AppsDataModule)
+
+    single { Clock.System } bind Clock::class
 
     factoryOf(::GetAllAvailableApps)
     factoryOf(::GetAvailableAppsLegacy)

--- a/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/GetInstalledApps.kt
+++ b/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/GetInstalledApps.kt
@@ -41,9 +41,9 @@ class GetInstalledApps(
                             installedApp.toCachedApp()
                         }
                     )
-                    lastSearchQuery = searchTerm
                     lastCacheRefresh = queryTime
                 }
+                lastSearchQuery = searchTerm
             }
             .mapLatest { cachedInstalledApps ->
                 cachedInstalledApps.map { cachedApp ->

--- a/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/GetInstalledApps.kt
+++ b/features/apps/logic/src/main/kotlin/com/nasdroid/apps/logic/installed/GetInstalledApps.kt
@@ -8,14 +8,21 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlin.time.Duration.Companion.minutes
 
 /**
  * Gets a list of applications installed on the system. See [invoke] for details.
  */
 class GetInstalledApps(
     private val chartReleaseV2Api: ChartReleaseV2Api,
-    private val installedAppCache: InstalledAppCache
+    private val installedAppCache: InstalledAppCache,
+    private val clock: Clock,
 ) {
+
+    private var lastSearchQuery: String? = null
+    private var lastCacheRefresh = Instant.DISTANT_PAST
 
     /**
      * Gets a list of all applications installed on the system.
@@ -24,46 +31,48 @@ class GetInstalledApps(
     operator fun invoke(searchTerm: String): Flow<List<InstalledAppOverview>> {
         return installedAppCache.getInstalledApps(searchTerm)
             .onStart {
-                val releaseDtos = chartReleaseV2Api.getChartReleases()
-                installedAppCache.submitInstalledApps(
-                    releaseDtos.map { installedApp ->
-                        CachedInstalledApp(
-                            name = installedApp.id,
-                            version = installedApp.humanVersion,
-                            iconUrl = installedApp.chartMetadata.icon,
-                            catalog = installedApp.catalog,
-                            train = installedApp.catalogTrain,
-                            state = when (installedApp.status) {
-                                ChartRelease.Status.DEPLOYING -> CachedInstalledApp.State.DEPLOYING
-                                ChartRelease.Status.ACTIVE -> CachedInstalledApp.State.ACTIVE
-                                ChartRelease.Status.STOPPED -> CachedInstalledApp.State.STOPPED
-                            },
-                            hasUpdateAvailable = installedApp.updateAvailable,
-                            webPortalUrl = installedApp.portals?.let { portals ->
-                                portals.open?.firstOrNull() ?: portals.webPortal?.firstOrNull()
-                            }
-                        )
-                    }
-                )
+                val queryTime = clock.now()
+                val isNewQuery = (lastSearchQuery != searchTerm)
+                val isCacheStale = (queryTime - lastCacheRefresh) > CacheValidityTimer
+                if (!isNewQuery || isCacheStale) {
+                    val releaseDtos = chartReleaseV2Api.getChartReleases()
+                    installedAppCache.submitInstalledApps(
+                        releaseDtos.map { installedApp ->
+                            installedApp.toCachedApp()
+                        }
+                    )
+                    lastSearchQuery = searchTerm
+                    lastCacheRefresh = queryTime
+                }
             }
             .mapLatest { cachedInstalledApps ->
                 cachedInstalledApps.map { cachedApp ->
-                    InstalledAppOverview(
-                        name = cachedApp.name,
-                        version = cachedApp.version,
-                        iconUrl = cachedApp.iconUrl,
-                        catalog = cachedApp.catalog,
-                        train = cachedApp.train,
-                        state = when (cachedApp.state) {
-                            CachedInstalledApp.State.ACTIVE -> InstalledAppOverview.State.ACTIVE
-                            CachedInstalledApp.State.STOPPED -> InstalledAppOverview.State.STOPPED
-                            CachedInstalledApp.State.DEPLOYING -> InstalledAppOverview.State.DEPLOYING
-                        },
-                        hasUpdateAvailable = cachedApp.hasUpdateAvailable,
-                        webPortalUrl = cachedApp.webPortalUrl
-                    )
+                    InstalledAppOverview(cachedApp)
                 }.sortedBy { app -> app.name }
             }
+    }
+
+    private fun ChartRelease.toCachedApp(): CachedInstalledApp {
+        return CachedInstalledApp(
+            name = id,
+            version = humanVersion,
+            iconUrl = chartMetadata.icon,
+            catalog = catalog,
+            train = catalogTrain,
+            state = when (status) {
+                ChartRelease.Status.DEPLOYING -> CachedInstalledApp.State.DEPLOYING
+                ChartRelease.Status.ACTIVE -> CachedInstalledApp.State.ACTIVE
+                ChartRelease.Status.STOPPED -> CachedInstalledApp.State.STOPPED
+            },
+            hasUpdateAvailable = updateAvailable,
+            webPortalUrl = portals?.let { portals ->
+                portals.open?.firstOrNull() ?: portals.webPortal?.firstOrNull()
+            }
+        )
+    }
+
+    companion object {
+        private val CacheValidityTimer = 1.minutes
     }
 }
 
@@ -89,6 +98,21 @@ data class InstalledAppOverview(
     val hasUpdateAvailable: Boolean,
     val webPortalUrl: String?
 ) {
+    internal constructor(cachedApp: CachedInstalledApp) : this(
+        name = cachedApp.name,
+        version = cachedApp.version,
+        iconUrl = cachedApp.iconUrl,
+        catalog = cachedApp.catalog,
+        train = cachedApp.train,
+        state = when (cachedApp.state) {
+            CachedInstalledApp.State.ACTIVE -> State.ACTIVE
+            CachedInstalledApp.State.STOPPED -> State.STOPPED
+            CachedInstalledApp.State.DEPLOYING -> State.DEPLOYING
+        },
+        hasUpdateAvailable = cachedApp.hasUpdateAvailable,
+        webPortalUrl = cachedApp.webPortalUrl
+    )
+
     /**
      * Possible states an application may be in.
      */


### PR DESCRIPTION
The app cache will only be refreshed when either
- The consumer is not searching for a new query
  - This implies they are trying to refresh the data
- The cache hasn't been updated for over a minute
  - Value chosen arbitrarily, it seems to work well for quick searches