### PR TITLE
Disallow gestures when navigation is not visible

### DIFF
--- a/app/src/main/java/com/nasdroid/ui/navigation/TopLevelNavigation.kt
+++ b/app/src/main/java/com/nasdroid/ui/navigation/TopLevelNavigation.kt
@@ -146,6 +146,7 @@ fun TopLevelNavigation(
                 content = navigationScaffold,
                 modifier = modifier,
                 headerContent = drawerHeaderContent,
+                gesturesEnabled = navigationVisible
             )
         }
         PrimaryNavigationMode.Permanent -> {


### PR DESCRIPTION
This fixes a bug where the nav drawer could be opened on the login screen