### PR TITLE
Strongly-typed errors for authentication

### DIFF
--- a/features/auth/logic/build.gradle.kts
+++ b/features/auth/logic/build.gradle.kts
@@ -35,6 +35,7 @@ detekt {
 }
 
 dependencies {
+    api(projects.core.strongResult)
     implementation(projects.core.api)
     implementation(projects.features.auth.data)
 

--- a/features/auth/logic/src/main/kotlin/com/nasdroid/auth/logic/auth/LogIn.kt
+++ b/features/auth/logic/src/main/kotlin/com/nasdroid/auth/logic/auth/LogIn.kt
@@ -2,10 +2,15 @@ package com.nasdroid.auth.logic.auth
 
 import com.nasdroid.api.ApiStateProvider
 import com.nasdroid.api.Authorization
+import com.nasdroid.api.exception.ClientRequestException
+import com.nasdroid.api.exception.ServerResponseException
+import com.nasdroid.api.v2.core.CoreV2Api
 import com.nasdroid.auth.data.currentserver.CurrentServerSource
 import com.nasdroid.auth.data.serverstore.AuthenticatedServersStore
 import com.nasdroid.auth.data.serverstore.Authentication
 import com.nasdroid.auth.logic.Server
+import com.nasdroid.core.strongresult.StrongResult
+import java.net.UnknownHostException
 
 /**
  * Attempts to authenticate with a server. See [invoke] for details.
@@ -14,25 +19,68 @@ class LogIn(
     private val apiStateProvider: ApiStateProvider,
     private val authenticatedServersStore: AuthenticatedServersStore,
     private val currentServerSource: CurrentServerSource,
+    private val coreV2Api: CoreV2Api,
 ) {
 
     /**
      * Attempts to authenticate with the given [Server]. If the stored token does not work, an error
      * is returned.
      */
-    suspend operator fun invoke(server: Server) : Result<Unit> = runCatching {
+    suspend operator fun invoke(server: Server) : StrongResult<Unit, LoginError> {
         val authentication = authenticatedServersStore.getAuthentication(server.id)
-        apiStateProvider.serverAddress = server.url
-        apiStateProvider.authorization = when (authentication) {
-            is Authentication.ApiKey -> Authorization.ApiKey(authentication.key)
-            is Authentication.Basic -> Authorization.Basic(authentication.username, authentication.password)
-        }
-        currentServerSource.setCurrentServer(
-            com.nasdroid.auth.data.Server(
-                uid = server.id,
-                name = server.name,
-                serverAddress = server.url
+        return try {
+            apiStateProvider.serverAddress = server.url
+            apiStateProvider.authorization = when (authentication) {
+                is Authentication.ApiKey -> Authorization.ApiKey(authentication.key)
+                is Authentication.Basic -> Authorization.Basic(authentication.username, authentication.password)
+            }
+
+            // Try to ping the server to see if our credentials and connection are OK
+            coreV2Api.ping()
+
+            currentServerSource.setCurrentServer(
+                com.nasdroid.auth.data.Server(
+                    uid = server.id,
+                    name = server.name,
+                    serverAddress = server.url
+                )
             )
-        )
+            StrongResult.success(Unit)
+        } catch (_: ClientRequestException) {
+            apiStateProvider.serverAddress = null
+            apiStateProvider.authorization = null
+            StrongResult.failure(LoginError.InvalidCredentials)
+        } catch (_: ServerResponseException) {
+            apiStateProvider.serverAddress = null
+            apiStateProvider.authorization = null
+            StrongResult.failure(LoginError.Unknown)
+        } catch (_: UnknownHostException) {
+            apiStateProvider.serverAddress = null
+            apiStateProvider.authorization = null
+            StrongResult.failure(LoginError.ServerUnreachable)
+        }
     }
+}
+
+/**
+ * Encapsulates all possible errors that can happen during the login process.
+ */
+sealed interface LoginError {
+
+    /**
+     * Indicates that the server could not be reached. This could be because the server is offline
+     * or on a different network. This could also mean the device has no internet.
+     */
+    data object ServerUnreachable : LoginError
+
+    /**
+     * Indicates that the credentials used were not valid for the target server. This could be
+     * because the token used was revoked, or the account password was changed.
+     */
+    data object InvalidCredentials : LoginError
+
+    /**
+     * Indicates an unexpected error occurred. We're not sure what could cause this.
+     */
+    data object Unknown : LoginError
 }

--- a/features/auth/ui/src/main/kotlin/com/nasdroid/auth/ui/serverselect/SelectServerErrorDialog.kt
+++ b/features/auth/ui/src/main/kotlin/com/nasdroid/auth/ui/serverselect/SelectServerErrorDialog.kt
@@ -1,0 +1,77 @@
+package com.nasdroid.auth.ui.serverselect
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material.icons.filled.KeyOff
+import androidx.compose.material.icons.filled.LinkOff
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import com.nasdroid.auth.ui.R
+
+/**
+ * Displays a dialog to communicate a [LoginState.Error] to the user.
+ */
+@Composable
+fun SelectServerErrorDialog(
+    onDismissRequest: () -> Unit,
+    error: LoginState.Error,
+    modifier: Modifier = Modifier
+) {
+    when (error) {
+        LoginState.Error.CredentialsInvalid -> {
+            GenericErrorDialog(
+                icon = Icons.Default.KeyOff,
+                title = stringResource(R.string.error_invalid_credentials_title),
+                text = stringResource(R.string.error_invalid_credentials_text),
+                onDismissRequest = onDismissRequest,
+                modifier = modifier
+            )
+        }
+        LoginState.Error.Generic -> {
+            GenericErrorDialog(
+                icon = Icons.Default.Error,
+                title = stringResource(R.string.error_unknown_title),
+                text = stringResource(R.string.error_unknown_text),
+                onDismissRequest = onDismissRequest,
+                modifier = modifier
+            )
+        }
+        LoginState.Error.ServerUnreachable -> {
+            GenericErrorDialog(
+                icon = Icons.Default.LinkOff,
+                title = stringResource(R.string.error_server_unreachable_title),
+                text = stringResource(R.string.error_server_unreachable_text),
+                onDismissRequest = onDismissRequest,
+                modifier = modifier
+            )
+        }
+    }
+}
+
+@Composable
+internal fun GenericErrorDialog(
+    icon: ImageVector,
+    title: String,
+    text: String,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    AlertDialog(
+        onDismissRequest = onDismissRequest,
+        icon = { Icon(icon, contentDescription = null) },
+        title = { Text(title) },
+        text = { Text(text) },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text("OK")
+            }
+        },
+        modifier = modifier
+    )
+}

--- a/features/auth/ui/src/main/kotlin/com/nasdroid/auth/ui/serverselect/SelectServerScreen.kt
+++ b/features/auth/ui/src/main/kotlin/com/nasdroid/auth/ui/serverselect/SelectServerScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import com.nasdroid.auth.logic.Server
 import com.nasdroid.design.MaterialThemeExt
-import kotlinx.coroutines.flow.collectLatest
 import org.koin.androidx.compose.koinViewModel
 
 /**
@@ -54,22 +53,15 @@ fun SelectServerScreen(
     viewModel: SelectServerViewModel = koinViewModel()
 ) {
     val authenticatedServers by viewModel.authenticatedServers.collectAsState()
-    val isLoading by viewModel.isLoading.collectAsState()
-
-    LaunchedEffect(viewModel) {
-        viewModel.events.collectLatest { event ->
-            when (event) {
-                SelectServerViewModel.Event.LoginSuccess -> onLoginSuccess()
-                SelectServerViewModel.Event.LoginFailedTokenInvalid -> TODO()
-                SelectServerViewModel.Event.LoginFailedServerNotFound -> TODO()
-                null -> return@collectLatest
-            }
-            viewModel.clearPendingEvent()
+    val loginState by viewModel.loginState.collectAsState()
+    LaunchedEffect(loginState) {
+        if (loginState == LoginState.LoginSuccess) {
+            onLoginSuccess()
         }
     }
 
     SelectServerContent(
-        isLoading = isLoading,
+        isLoading = loginState == LoginState.Loading,
         servers = authenticatedServers,
         onServerClick = viewModel::tryLogIn,
         onAddServerClick = onAddServer,

--- a/features/auth/ui/src/main/kotlin/com/nasdroid/auth/ui/serverselect/SelectServerScreen.kt
+++ b/features/auth/ui/src/main/kotlin/com/nasdroid/auth/ui/serverselect/SelectServerScreen.kt
@@ -69,6 +69,10 @@ fun SelectServerScreen(
         modifier = modifier,
         contentPadding = contentPadding,
     )
+
+    (loginState as? LoginState.Error)?.let {
+        SelectServerErrorDialog(onDismissRequest = viewModel::clearPendingEvent, error = it)
+    }
 }
 
 /**

--- a/features/auth/ui/src/main/kotlin/com/nasdroid/auth/ui/serverselect/SelectServerViewModel.kt
+++ b/features/auth/ui/src/main/kotlin/com/nasdroid/auth/ui/serverselect/SelectServerViewModel.kt
@@ -60,9 +60,9 @@ class SelectServerViewModel(
                 onSuccess = { LoginState.LoginSuccess },
                 onFailure = {
                     when (it) {
-                        LoginError.InvalidCredentials -> LoginState.ErrorCredentialsInvalid
-                        LoginError.ServerUnreachable -> LoginState.ErrorServerUnreachable
-                        LoginError.Unknown -> LoginState.ErrorGeneric
+                        LoginError.InvalidCredentials -> LoginState.Error.CredentialsInvalid
+                        LoginError.ServerUnreachable -> LoginState.Error.ServerUnreachable
+                        LoginError.Unknown -> LoginState.Error.Generic
                     }
                 }
             )
@@ -74,10 +74,36 @@ class SelectServerViewModel(
 /**
  * Describes various events that the ViewModel may emit.
  */
-enum class LoginState {
-    Loading,
-    LoginSuccess,
-    ErrorCredentialsInvalid,
-    ErrorServerUnreachable,
-    ErrorGeneric
+sealed interface LoginState {
+
+    /**
+     * The login screen is currently processing a request.
+     */
+    data object Loading : LoginState
+
+    /**
+     * The login screen has successfully authenticated with a server.
+     */
+    data object LoginSuccess : LoginState
+
+    /**
+     * An error occurred during the login process.
+     */
+    sealed interface Error : LoginState {
+
+        /**
+         * A login request was made with the server, but we were unauthorized.
+         */
+        data object CredentialsInvalid : Error
+
+        /**
+         * A login request could not be made to the server because it was not found.
+         */
+        data object ServerUnreachable : Error
+
+        /**
+         * The login request failed for an undefined reason.
+         */
+        data object Generic : Error
+    }
 }

--- a/features/auth/ui/src/main/res/values/strings.xml
+++ b/features/auth/ui/src/main/res/values/strings.xml
@@ -20,4 +20,11 @@
     
     <string name="basic_auth_warning">Your password will be stored securely in-app. We recommend using an API key for added control.</string>
     <string name="switch_api_key">Use an API key</string>
+
+    <string name="error_invalid_credentials_title">Invalid Credentials</string>
+    <string name="error_invalid_credentials_text">The credentials we have stored were rejected by the server</string>
+    <string name="error_unknown_title">Unknown Error</string>
+    <string name="error_unknown_text">Something went wrong, but we\'re not exactly sure what</string>
+    <string name="error_server_unreachable_title">Server Unreachable</string>
+    <string name="error_server_unreachable_text">We couldn\'t reach the server. Make sure you are connected to the network, and that your server is powered on</string>
 </resources>


### PR DESCRIPTION
The standard login flow will now try to validate the server it's connected to before deciding we are authenticated.
Failures to do so are encapsulated in a finite set of cases, so we can explicitly handle each case from the UI as needed.