### PR TITLE
Set up versioning with CalVer

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -108,7 +108,7 @@ dependencies {
  * Calculates an appropriate version name, based on [CalVer](https://calver.org/).
  */
 fun calculateVersionName(): String {
-    val formatter = DateTimeFormatter.ofPattern("YYYY.M")
+    val formatter = DateTimeFormatter.ofPattern("YYYY.W")
     val nowDate = LocalDate.now()
     return nowDate.format(formatter)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,6 @@
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -9,9 +12,10 @@ android {
     namespace = "com.nasdroid"
 
     defaultConfig {
+        val workflowRun: Int? by project
         applicationId = "com.nasdroid"
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = workflowRun ?: 1
+        versionName = calculateVersionName()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -98,4 +102,13 @@ dependencies {
 
     testImplementation(libs.kotlin.test)
     androidTestImplementation(libs.androidx.test.ext.junit)
+}
+
+/**
+ * Calculates an appropriate version name, based on [CalVer](https://calver.org/).
+ */
+fun calculateVersionName(): String {
+    val formatter = DateTimeFormatter.ofPattern("YYYY.M")
+    val nowDate = LocalDate.now()
+    return nowDate.format(formatter)
 }


### PR DESCRIPTION
https://calver.org/

NASdroid is versioned as `YYYY.WW` (this translates to `YYYY.W` in Java date format syntax).
As an example, right now NASdroid version is `2024.5`.

I also added a way to define the versionCode. This is intentionally not set for nightlies to avoid conflicts with non-nightlies (for now)