### PR TITLE
Initial implementation of basic temporal aggregation for reporting data

### DIFF
--- a/features/reporting/logic/src/main/kotlin/com/nasdroid/reporting/logic/graph/GraphData.kt
+++ b/features/reporting/logic/src/main/kotlin/com/nasdroid/reporting/logic/graph/GraphData.kt
@@ -44,13 +44,17 @@ data class GraphData<T>(
                 name.replace("{identifier}", it)
             } ?: name
             return GraphData(
-                dataSlices = data.map { data ->
-                    val dataNoNulls = data.requireNoNulls()
-                    DataSlice(
-                        timestamp = Instant.fromEpochMilliseconds(dataNoNulls.first().toLong()),
-                        data = dataToType(dataNoNulls.drop(1))
-                    )
-                },
+                dataSlices = data
+                    .map { data ->
+                        val dataNoNulls = data.requireNoNulls()
+                        val timestampSeconds = dataNoNulls.first().toLong()
+                        val roundedTimestamp = timestampSeconds - (timestampSeconds % 30)
+                        DataSlice(
+                            timestamp = Instant.fromEpochMilliseconds(roundedTimestamp),
+                            data = dataToType(dataNoNulls.drop(1))
+                        )
+                    }
+                    .distinctBy { it.timestamp },
                 legend = legend.drop(1),
                 name = formattedName,
                 identifier = identifier,

--- a/features/reporting/logic/src/main/kotlin/com/nasdroid/reporting/logic/graph/GraphData.kt
+++ b/features/reporting/logic/src/main/kotlin/com/nasdroid/reporting/logic/graph/GraphData.kt
@@ -37,6 +37,8 @@ data class GraphData<T>(
     )
 
     companion object {
+        private const val TEMPORAL_AGGREGATION_SECONDS = 30
+
         internal fun <T> ReportingGraphData.toGraphData(
             dataToType: (List<Double>) -> List<T>
         ): GraphData<T> {
@@ -48,7 +50,7 @@ data class GraphData<T>(
                     .map { data ->
                         val dataNoNulls = data.requireNoNulls()
                         val timestampSeconds = dataNoNulls.first().toLong()
-                        val roundedTimestamp = timestampSeconds - (timestampSeconds % 30)
+                        val roundedTimestamp = timestampSeconds - (timestampSeconds % TEMPORAL_AGGREGATION_SECONDS)
                         DataSlice(
                             timestamp = Instant.fromEpochMilliseconds(roundedTimestamp),
                             data = dataToType(dataNoNulls.drop(1))


### PR DESCRIPTION
This should reduce data points by ~6x, speeding up rendering of the new reporting experience.