### PR TITLE
Add support for JSON-RPC API

### DIFF
--- a/apitester/src/androidMain/kotlin/com/nasdroid/apitester/MainViewModel.kt
+++ b/apitester/src/androidMain/kotlin/com/nasdroid/apitester/MainViewModel.kt
@@ -1,11 +1,11 @@
 package com.nasdroid.apitester
 
 import androidx.lifecycle.ViewModel
-import com.nasdroid.api.websocket.ddp.DdpWebsocketClient
+import com.nasdroid.api.websocket.jsonrpc.JsonRpcWebsocketClient
 import kotlinx.coroutines.runBlocking
 
 class MainViewModel : ViewModel() {
-    val client = DdpWebsocketClient()
+    val client = JsonRpcWebsocketClient()
 
     override fun onCleared() {
         super.onCleared()

--- a/apitester/src/commonMain/kotlin/com/nasdroid/apitester/App.kt
+++ b/apitester/src/commonMain/kotlin/com/nasdroid/apitester/App.kt
@@ -5,30 +5,30 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
-import com.nasdroid.api.websocket.ddp.DdpWebsocketClient
+import com.nasdroid.api.websocket.jsonrpc.JsonRpcWebsocketClient
 import com.nasdroid.apitester.connect.ConnectScreen
 import com.nasdroid.apitester.connect.ConnectingScreen
 import kotlinx.coroutines.launch
 
 @Composable
 fun App(
-    client: DdpWebsocketClient
+    client: JsonRpcWebsocketClient
 ) {
     val coroutineScope = rememberCoroutineScope()
     val state by client.state.collectAsState()
     MaterialTheme {
         when (state) {
-            is DdpWebsocketClient.State.Connected -> {
+            is JsonRpcWebsocketClient.State.Connected -> {
                 TesterScreen(client)
             }
-            DdpWebsocketClient.State.Connecting -> {
+            JsonRpcWebsocketClient.State.Connecting -> {
                 ConnectingScreen()
             }
-            DdpWebsocketClient.State.Disconnected -> {
+            JsonRpcWebsocketClient.State.Disconnected -> {
                 ConnectScreen(
-                    onConnect = { url, session ->
+                    onConnect = { url ->
                         coroutineScope.launch {
-                            client.connect(url, session)
+                            client.connect(url)
                         }
                     }
                 )

--- a/apitester/src/commonMain/kotlin/com/nasdroid/apitester/TesterScreen.kt
+++ b/apitester/src/commonMain/kotlin/com/nasdroid/apitester/TesterScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -24,13 +23,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
-import com.nasdroid.api.websocket.ddp.DdpWebsocketClient
+import com.nasdroid.api.websocket.jsonrpc.JsonRpcWebsocketClient
 import com.nasdroid.apitester.methods.MethodCallScreen
-import kotlinx.serialization.json.JsonElement
 
 @Composable
 fun TesterScreen(
-    client: DdpWebsocketClient,
+    client: JsonRpcWebsocketClient,
     modifier: Modifier = Modifier
 ) {
     var destination by rememberSaveable { mutableStateOf(TesterDestination.MethodCall) }
@@ -46,16 +44,6 @@ fun TesterScreen(
                     Text("Method Call")
                 }
             )
-            item(
-                selected = destination == TesterDestination.Subscription,
-                onClick = { destination = TesterDestination.Subscription },
-                icon = {
-                    Icon(Icons.Default.Commit, null)
-                },
-                label = {
-                    Text("Subscription")
-                }
-            )
         },
         modifier = modifier
     ) {
@@ -67,9 +55,6 @@ fun TesterScreen(
                         modifier = Modifier.fillMaxSize()
                     )
                 }
-                TesterDestination.Subscription -> {
-
-                }
             }
         }
     }
@@ -77,7 +62,6 @@ fun TesterScreen(
 
 enum class TesterDestination {
     MethodCall,
-    Subscription
 }
 
 @Composable

--- a/apitester/src/commonMain/kotlin/com/nasdroid/apitester/connect/ConnectScreen.kt
+++ b/apitester/src/commonMain/kotlin/com/nasdroid/apitester/connect/ConnectScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MediumTopAppBar
@@ -17,16 +18,16 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConnectScreen(
-    onConnect: (url: String, session: String?) -> Unit,
+    onConnect: (url: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
     var url by rememberSaveable { mutableStateOf("") }
-    var session by rememberSaveable { mutableStateOf("") }
     Scaffold(
         topBar = {
             MediumTopAppBar(
@@ -49,16 +50,13 @@ fun ConnectScreen(
                 onValueChange = { url = it },
                 label = {
                     Text("Server URL (Required)")
-                }
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    keyboardType = KeyboardType.Uri
+                )
             )
-            TextField(
-                value = session,
-                onValueChange = { session = it },
-                label = {
-                    Text("Session ID (Optional)")
-                }
-            )
-            Button(onClick = { onConnect(url, session.takeIf { it.isNotBlank() }) }) {
+            Button(onClick = { onConnect(url) }) {
                 Text("Connect")
             }
         }

--- a/apitester/src/commonMain/kotlin/com/nasdroid/apitester/methods/MethodCallScreen.kt
+++ b/apitester/src/commonMain/kotlin/com/nasdroid/apitester/methods/MethodCallScreen.kt
@@ -13,11 +13,11 @@ import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.window.core.layout.WindowSizeClass
 import androidx.window.core.layout.WindowWidthSizeClass
-import com.nasdroid.api.websocket.ddp.DdpWebsocketClient
+import com.nasdroid.api.websocket.jsonrpc.JsonRpcWebsocketClient
 
 @Composable
 fun MethodCallScreen(
-    client: DdpWebsocketClient,
+    client: JsonRpcWebsocketClient,
     modifier: Modifier = Modifier,
     viewModel: MethodCallViewModel = viewModel { MethodCallViewModel(client) },
     windowSizeClass: WindowSizeClass = currentWindowAdaptiveInfo().windowSizeClass,

--- a/apitester/src/commonMain/kotlin/com/nasdroid/apitester/methods/MethodCallViewModel.kt
+++ b/apitester/src/commonMain/kotlin/com/nasdroid/apitester/methods/MethodCallViewModel.kt
@@ -2,16 +2,16 @@ package com.nasdroid.apitester.methods
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.nasdroid.api.websocket.ddp.DdpWebsocketClient
-import com.nasdroid.api.websocket.ddp.MethodCallError
-import com.nasdroid.api.websocket.ddp.callMethod
+import com.nasdroid.api.websocket.jsonrpc.JsonRpcWebsocketClient
+import com.nasdroid.api.websocket.jsonrpc.MethodCallError
+import com.nasdroid.api.websocket.jsonrpc.callMethod
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonElement
 
-class MethodCallViewModel(private val client: DdpWebsocketClient) : ViewModel() {
+class MethodCallViewModel(private val client: JsonRpcWebsocketClient) : ViewModel() {
     private val _interactions = MutableStateFlow(emptyList<MethodInteraction>())
     val interactions: StateFlow<List<MethodInteraction>> = _interactions
 

--- a/apitester/src/jvmMain/kotlin/com/nasdroid/apitester/Main.kt
+++ b/apitester/src/jvmMain/kotlin/com/nasdroid/apitester/Main.kt
@@ -4,12 +4,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
-import com.nasdroid.api.websocket.ddp.DdpWebsocketClient
+import com.nasdroid.api.websocket.jsonrpc.JsonRpcWebsocketClient
 import kotlinx.coroutines.runBlocking
 
 fun main() = application {
     val state = rememberWindowState()
-    val client = remember { DdpWebsocketClient() }
+    val client = remember { JsonRpcWebsocketClient() }
     Window(
         title = "TrueNAS API Tester",
         onCloseRequest = {

--- a/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/ApiWebsocketModule.kt
+++ b/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/ApiWebsocketModule.kt
@@ -9,6 +9,7 @@ import com.nasdroid.api.websocket.auth.DdpAuthApi
 import com.nasdroid.api.websocket.core.CoreApi
 import com.nasdroid.api.websocket.core.DdpCoreApi
 import com.nasdroid.api.websocket.ddp.DdpWebsocketClient
+import com.nasdroid.api.websocket.jsonrpc.JsonRpcWebsocketClient
 import com.nasdroid.api.websocket.reporting.DdpReportingApi
 import com.nasdroid.api.websocket.reporting.ReportingApi
 import com.nasdroid.api.websocket.system.DdpSystemApi
@@ -19,6 +20,7 @@ import org.koin.dsl.module
 
 val ApiWebsocketModule = module {
     singleOf(::DdpWebsocketClient)
+    singleOf(::JsonRpcWebsocketClient)
 
     singleOf(::DdpAlertApi) bind AlertApi::class
     singleOf(::DdpAuthApi) bind AuthApi::class

--- a/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/JsonRpcMessage.kt
+++ b/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/JsonRpcMessage.kt
@@ -9,6 +9,20 @@ import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
+/**
+ * Describes an RPC call to be made to the server.
+ *
+ * @param P The type of [params].
+ *
+ * @property id An identifier established by the Client.
+ * @property method A String containing the name of the method to be invoked. Method names that begin
+ * with the word rpc followed by a period character (U+002E or ASCII 46) are reserved for
+ * rpc-internal methods and extensions and MUST NOT be used for anything else.
+ * @property params A Structured value that holds the parameter values to be used during the invocation
+ * of the method.
+ * @property jsonRpcVersion A String specifying the version of the JSON-RPC protocol. MUST be exactly
+ * "2.0".
+ */
 @Serializable
 data class RequestMessage<P>(
     @SerialName("id")
@@ -21,8 +35,21 @@ data class RequestMessage<P>(
     val jsonRpcVersion: String = "2.0",
 )
 
+/**
+ * Encapsulates possible responses from a [RequestMessage].
+ */
 sealed interface RpcResponse
 
+/**
+ * Indicates a successful response to [RequestMessage].
+ *
+ * @param T The type of [result].
+ *
+ * @property id An identifier established by the Client.
+ * @property result The result of the call.
+ * @property jsonRpcVersion A String specifying the version of the JSON-RPC protocol. MUST be exactly
+ * "2.0".
+ */
 @Serializable
 data class ResponseMessage<T>(
     @SerialName("id")
@@ -33,6 +60,14 @@ data class ResponseMessage<T>(
     val jsonRpcVersion: String,
 ) : RpcResponse
 
+/**
+ * Indicates a failed response to [RequestMessage].
+ *
+ * @property id An identifier established by the Client.
+ * @property error [Error].
+ * @property jsonRpcVersion A String specifying the version of the JSON-RPC protocol. MUST be exactly
+ * "2.0".
+ */
 @Serializable
 data class ResponseError(
     @SerialName("id")
@@ -42,14 +77,39 @@ data class ResponseError(
     @SerialName("jsonrpc")
     val jsonRpcVersion: String,
 ) : RpcResponse {
+    /**
+     * Describes an error that happened while making an RPC call.
+     *
+     * @property code A number that indicates the error type that occurred.
+     * @property message A short description of the error.
+     * @property data An optional element that contains error details.
+     */
     @Serializable
     data class Error(
         val code: Int,
         val message: String,
-        val data: JsonObject
+        val data: JsonElement?
     )
 }
 
+/**
+ * A Notification is a Request object without an "id" member. A Request object that is a
+ * Notification signifies the Client's lack of interest in the corresponding Response object, and as
+ * such no Response object needs to be returned to the client. The Server MUST NOT reply to a
+ * Notification, including those that are within a batch request.
+ *
+ * Notifications are not confirmable by definition, since they do not have a Response object to be
+ * returned. As such, the Client would not be aware of any errors (like e.g. "Invalid params",
+ * "Internal error").
+ *
+ * @property method A String containing the name of the method to be invoked. Method names that begin
+ * with the word rpc followed by a period character (U+002E or ASCII 46) are reserved for
+ * rpc-internal methods and extensions and MUST NOT be used for anything else.
+ * @property params A Structured value that holds the parameter values to be used during the invocation
+ * of the method.
+ * @property jsonRpcVersion A String specifying the version of the JSON-RPC protocol. MUST be exactly
+ * "2.0".
+ */
 @Serializable
 data class Notification(
     @SerialName("method")
@@ -60,12 +120,13 @@ data class Notification(
     val jsonRpcVersion: String,
 )
 
-class RpcResponseSerializer<T>(
-    val responseSerializer: KSerializer<T>
+internal class RpcResponseSerializer(
+    val responseSerializer: KSerializer<*>
 ) : JsonContentPolymorphicSerializer<RpcResponse>(RpcResponse::class) {
     override fun selectDeserializer(element: JsonElement): DeserializationStrategy<RpcResponse> {
-        if (element !is JsonObject)
+        if (element !is JsonObject) {
             throw SerializationException("Attempted to deserialize $element, but it wasn't a valid object!")
+        }
 
         return if (element.contains("result")) {
             ResponseMessage.serializer(responseSerializer)

--- a/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/JsonRpcMessage.kt
+++ b/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/JsonRpcMessage.kt
@@ -1,0 +1,76 @@
+package com.nasdroid.api.websocket.jsonrpc
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+
+@Serializable
+data class RequestMessage<P>(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("method")
+    val method: String,
+    @SerialName("params")
+    val params: List<P>,
+    @SerialName("jsonrpc")
+    val jsonRpcVersion: String = "2.0",
+)
+
+sealed interface RpcResponse
+
+@Serializable
+data class ResponseMessage<T>(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("result")
+    val result: T,
+    @SerialName("jsonrpc")
+    val jsonRpcVersion: String,
+) : RpcResponse
+
+@Serializable
+data class ResponseError(
+    @SerialName("id")
+    val id: Int,
+    @SerialName("error")
+    val error: Error,
+    @SerialName("jsonrpc")
+    val jsonRpcVersion: String,
+) : RpcResponse {
+    @Serializable
+    data class Error(
+        val code: Int,
+        val message: String,
+        val data: JsonObject
+    )
+}
+
+@Serializable
+data class Notification(
+    @SerialName("method")
+    val method: String,
+    @SerialName("params")
+    val params: JsonObject,
+    @SerialName("jsonrpc")
+    val jsonRpcVersion: String,
+)
+
+class RpcResponseSerializer<T>(
+    val responseSerializer: KSerializer<T>
+) : JsonContentPolymorphicSerializer<RpcResponse>(RpcResponse::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<RpcResponse> {
+        if (element !is JsonObject)
+            throw SerializationException("Attempted to deserialize $element, but it wasn't a valid object!")
+
+        return if (element.contains("result")) {
+            ResponseMessage.serializer(responseSerializer)
+        } else {
+            ResponseError.serializer()
+        }
+    }
+}

--- a/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/JsonRpcWebsocketClient.kt
+++ b/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/JsonRpcWebsocketClient.kt
@@ -1,0 +1,233 @@
+package com.nasdroid.api.websocket.jsonrpc
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.plugins.websocket.DefaultClientWebSocketSession
+import io.ktor.client.plugins.websocket.WebSockets
+import io.ktor.client.plugins.websocket.pingInterval
+import io.ktor.client.plugins.websocket.webSocketSession
+import io.ktor.websocket.Frame
+import io.ktor.websocket.close
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromStream
+import kotlinx.serialization.serializer
+import kotlin.concurrent.atomics.AtomicInt
+import kotlin.concurrent.atomics.ExperimentalAtomicApi
+import kotlin.concurrent.atomics.fetchAndIncrement
+import kotlin.time.Duration.Companion.minutes
+import kotlin.uuid.ExperimentalUuidApi
+
+/**
+ * A websocket client following [JSON-RPC 2.0](https://www.jsonrpc.org/specification).
+ *
+ * Before executing any calls, you'll need to [connect] successfully.
+ */
+@OptIn(ExperimentalAtomicApi::class)
+class JsonRpcWebsocketClient {
+    private val idCounter = AtomicInt(1)
+
+    private val bootstrapLock = Mutex()
+
+    private val _state = MutableStateFlow<State>(State.Disconnected)
+
+    /**
+     * The current state of the client. See [State] for all states.
+     */
+    val state: StateFlow<State> = _state
+
+    /**
+     * Attempts to open a connection to a JSON-RPC server at [url].
+     *
+     * When the connection succeeds, [state] is updated to [State.Connected], and this function
+     * returns. However, if the connection fails, an [IllegalStateException] is thrown and the state
+     * is reset.
+     *
+     * @throws IllegalStateException when the server rejects the connection.
+     * @throws java.net.UnknownHostException when the server at [url] was not reachable.
+     */
+    suspend fun connect(url: String) {
+        bootstrapLock.withLock {
+            check(state.value is State.Disconnected) { "Cannot connect when already connected or connecting." }
+            _state.value = State.Connecting
+            try {
+                val webSocket = WebsocketKtorClient.webSocketSession(urlString = url)
+                _state.value = State.Connected(webSocket)
+            } finally {
+                // Ensure state is never connecting when we finish
+                if (_state.value is State.Connecting) {
+                    _state.value = State.Disconnected
+                }
+            }
+        }
+    }
+
+    /**
+     * Disconnects from the connected session, or does nothing if not already connected.
+     *
+     * In case the client is connecting when this is called, this will suspend until connection
+     * completes.
+     */
+    suspend fun disconnect() {
+        bootstrapLock.withLock {
+            when (val currentState = state.value) {
+                is State.Connected -> {
+                    currentState.webSocketSession.close()
+                    _state.value = State.Disconnected
+                }
+                is State.Connecting -> {
+                    error("Attempted to disconnect while connecting. This should be impossible!")
+                }
+                State.Disconnected -> { /* Already disconnected, no-op */ }
+            }
+        }
+    }
+
+    /**
+     * Performs an RPC call on the connected session.
+     *
+     * @param T The type of data to be returned from the method call.
+     * @param P The type of parameters to be sent alongside the method call.
+     *
+     * @param method The method to call. Check your server documentation for available methods.
+     * @param serializer The [KSerializer] used to deserialize the result.
+     * @param params A list of optional parameters to send along with the method call.
+     * @param paramSerializer The serializer for parameter items.
+     *
+     * @throws IllegalStateException if the client wasn't connected with [connect] before making the
+     * call.
+     * @throws MethodCallError if the server returned an error in response to the method call.
+     * @throws SerializeError if the client failed to construct the method call. In this
+     * situation, nothing was sent to the server.
+     * @throws DeserializeError if the client failed to deserialize the method result.
+     */
+    @OptIn(ExperimentalUuidApi::class, ExperimentalSerializationApi::class)
+    suspend fun <T, P> callMethod(
+        method: String,
+        serializer: KSerializer<T>,
+        params: List<P>,
+        paramSerializer: KSerializer<P>
+    ): T {
+        val currentState = state.value
+        check(currentState is State.Connected) { "Client must be connected before making any method calls!" }
+
+        val message = RequestMessage(idCounter.fetchAndIncrement(), method, params)
+        val serializedString = try {
+            Json.encodeToString(RequestMessage.serializer(paramSerializer), message)
+        } catch (e: SerializationException) {
+            throw SerializeError(e)
+        }
+        currentState.webSocketSession.send(Frame.Text(serializedString))
+        val resultFrame = currentState.webSocketSession.incoming.receive()
+        val result = try {
+            Json.decodeFromStream(ResponseMessage.serializer(serializer), resultFrame.data.inputStream())
+        } catch (e: SerializationException) {
+            throw DeserializeError(e, resultFrame.data.decodeToString())
+        }
+        return result.result
+    }
+
+    /**
+     * Performs an RPC call on the connected session.
+     *
+     * @param T The type of data to be returned from the method call.
+     *
+     * @param method The method to call. Check your server documentation for available methods.
+     * @param serializer The [KSerializer] used to deserialize the result.
+     *
+     * @throws IllegalStateException if the client wasn't connected with [connect] before making the
+     * call.
+     * @throws MethodCallError if the server returned an error in response to the method call.
+     */
+    suspend fun <T> callMethod(
+        method: String,
+        serializer: KSerializer<T>,
+    ): T {
+        return callMethod(method, serializer, emptyList(), String.serializer())
+    }
+
+    /**
+     * Encapsulates possible states that [JsonRpcWebsocketClient] might be in.
+     */
+    sealed interface State {
+
+        /**
+         * The client is trying to connect to a server.
+         */
+        data object Connecting : State
+
+        /**
+         * The client successfully connected to the server.
+         *
+         * @property webSocketSession The internal websocket session powering the client.
+         */
+        data class Connected(
+            internal val webSocketSession: DefaultClientWebSocketSession,
+        ) : State
+
+        /**
+         * The client is not connected to any session. This is the default state. Call [connect] to
+         * get set up.
+         */
+        data object Disconnected : State
+    }
+}
+
+private val WebsocketKtorClient = HttpClient {
+    install(Logging) {
+        level = LogLevel.ALL
+        logger = object : Logger {
+            override fun log(message: String) {
+                println(message)
+            }
+        }
+    }
+
+    install(WebSockets) {
+        pingInterval = 1.minutes
+    }
+}
+
+/**
+ * Performs an RPC call on the connected session.
+ *
+ * @param T The type of data to be returned from the method call.
+ *
+ * @param method The method to call. Check your server documentation for available methods.
+ *
+ * @throws IllegalStateException if the client wasn't connected with
+ * [com.nasdroid.api.websocket.ddp.DdpWebsocketClient.connect] before making the call.
+ * @throws MethodCallError if the server returned an error in response to the method call.
+ */
+suspend inline fun <reified T> JsonRpcWebsocketClient.callMethod(method: String): T {
+    return callMethod(method, serializer())
+}
+
+/**
+ * Performs an RPC call on the connected session.
+ *
+ * @param T The type of data to be returned from the method call.
+ * @param P The type of parameters to be sent alongside the method call.
+ *
+ * @param method The method to call. Check your server documentation for available methods.
+ * @param params A list of optional parameters to send along with the method call.
+ *
+ * @throws IllegalStateException if the client wasn't connected with
+ * [com.nasdroid.api.websocket.ddp.DdpWebsocketClient.connect] before making the call.
+ * @throws MethodCallError if the server returned an error in response to the method call.
+ */
+suspend inline fun <reified T, reified P> JsonRpcWebsocketClient.callMethod(
+    method: String,
+    params: List<P>
+): T {
+    return callMethod(method, serializer(), params, serializer())
+}

--- a/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/Throwables.kt
+++ b/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/Throwables.kt
@@ -4,9 +4,7 @@ package com.nasdroid.api.websocket.jsonrpc
  * A DDP websocket server responded with an error after attempting to perform a method call.
  */
 data class MethodCallError(
-    val error: String,
-    val errorType: String,
-    val reason: String? = null,
+    val errorCode: Int,
     override val message: String? = null,
 ) : Throwable()
 

--- a/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/Throwables.kt
+++ b/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/Throwables.kt
@@ -1,0 +1,21 @@
+package com.nasdroid.api.websocket.jsonrpc
+
+/**
+ * A DDP websocket server responded with an error after attempting to perform a method call.
+ */
+data class MethodCallError(
+    val error: String,
+    val errorType: String,
+    val reason: String? = null,
+    override val message: String? = null,
+) : Throwable()
+
+/**
+ * Something went wrong while trying to construct the RPC call to the server.
+ */
+data class SerializeError(override val cause: Throwable): Throwable(cause)
+
+/**
+ * Something went wrong while trying to deserialize the response received from the server.
+ */
+data class DeserializeError(override val cause: Throwable, val resultMessage: String): Throwable(cause)

--- a/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/Throwables.kt
+++ b/core/api/src/commonMain/kotlin/com/nasdroid/api/websocket/jsonrpc/Throwables.kt
@@ -2,6 +2,8 @@ package com.nasdroid.api.websocket.jsonrpc
 
 /**
  * A DDP websocket server responded with an error after attempting to perform a method call.
+ *
+ * @property errorCode The code describing the error type.
  */
 data class MethodCallError(
     val errorCode: Int,


### PR DESCRIPTION
This isn't quite ready for use - the new API docs don't mention the API endpoint, so we can't test this. Nevertheless, it does build and the tester has been updated for it.